### PR TITLE
Moved JDBC hystrix commands and spring to tests/test-scope 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Base Commands to be extended for your use for HTTP, REST and SOAP over Hystrix
 ```java
 
 /**
-* A simple example Command extending BaseHttpGetHystrixCommand
+*domainexample
 */
 public class CommandGetOauth2ProtectedPing extends BaseHttpGetHystrixCommand<String> {
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,6 @@
             <artifactId>http-request</artifactId>
             <version>6.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-            <version>4.2.5.RELEASE</version>
-        </dependency>
 
         <dependency>
             <groupId>com.netflix.hystrix</groupId>
@@ -115,6 +110,12 @@
         </dependency>
 
         <!--TEST-->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>4.2.5.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
             <artifactId>http-request</artifactId>
             <version>6.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>4.2.5.RELEASE</version>
+        </dependency>
 
         <dependency>
             <groupId>com.netflix.hystrix</groupId>

--- a/src/main/java/no/cantara/base/commands/BaseHystrixCommand.java
+++ b/src/main/java/no/cantara/base/commands/BaseHystrixCommand.java
@@ -1,0 +1,29 @@
+package no.cantara.base.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
+
+public abstract class BaseHystrixCommand<Response> extends HystrixCommand<Response> {
+    private final static int DEFAULT_TIMEOUT = 2000;
+
+    protected BaseHystrixCommand(String groupKey) {
+        this(groupKey, DEFAULT_TIMEOUT);
+    }
+
+    protected BaseHystrixCommand(String groupKey, int timeout) {
+        super(initializeCommand(groupKey, timeout));
+        HystrixRequestContext.initializeContext();
+    }
+
+    protected static HystrixCommand.Setter initializeCommand(String key, int timeout) {
+        HystrixCommandGroupKey groupKey = HystrixCommandGroupKey.Factory.asKey(key);
+        HystrixCommandProperties.Setter properties = HystrixCommandProperties.Setter()
+            .withExecutionTimeoutInMilliseconds(timeout);
+
+        return HystrixCommand.Setter
+            .withGroupKey(groupKey)
+            .andCommandPropertiesDefaults(properties);
+    }
+}

--- a/src/main/java/no/cantara/base/commands/factories/HttpCommandFactory.java
+++ b/src/main/java/no/cantara/base/commands/factories/HttpCommandFactory.java
@@ -1,0 +1,23 @@
+package no.cantara.base.commands.factories;
+
+import com.netflix.hystrix.HystrixCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpCommandFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(HttpCommandFactory.class);
+
+
+    public <Command extends HystrixCommand> Command createCommand(Class<Command> targetClass) {
+        try {
+            Command command = targetClass.newInstance();
+
+            return command;
+
+        } catch (Exception exception) {
+            LOG.error(String.format("Failed to create command %s", targetClass.getSimpleName()), exception);
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/no/cantara/base/commands/http/BaseHystrixHttpCommand.java
+++ b/src/main/java/no/cantara/base/commands/http/BaseHystrixHttpCommand.java
@@ -1,0 +1,98 @@
+package no.cantara.base.commands.http;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import no.cantara.base.commands.BaseHystrixCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Map;
+
+public abstract class BaseHystrixHttpCommand<Response> extends BaseHystrixCommand<Response> {
+    protected Logger log;
+
+    protected BaseHystrixHttpCommand(String groupKey, int timeout) {
+        super(groupKey, timeout);
+        initialize();
+    }
+
+    protected BaseHystrixHttpCommand(String groupKey) {
+        super(groupKey);
+        initialize();
+    }
+
+    protected abstract HttpRequest getRequest() throws MalformedURLException;
+    protected abstract Response dealWithResponse(HttpResponse response);
+
+    @Override
+    protected Response run() throws Exception {
+        try {
+            HttpRequest request = initializeRequest();
+
+            String url = request.url().toString();
+            String method = request.method();
+            log.trace("Request: {} - {}", method, url);
+
+            request = dealWithRequestBeforeSend(request);
+            HttpResponse response = getResponse(request);
+            onCompleted(response);
+
+            boolean isSuccessful = response.isSuccessful();
+            if (isSuccessful) {
+                return dealWithResponse(response);
+            }
+
+            return dealWithFailedResponse(response);
+        } catch(Exception exception) {
+            log.error("Request failed - Application authentication failed ", exception);
+            throw exception;
+        }
+    }
+
+    @Override
+    protected Response getFallback() {
+        log.trace("Fallback - Request failed");
+        return null;
+    }
+
+    protected Response dealWithFailedResponse(HttpResponse response) {
+        return null;
+    }
+
+    protected HttpRequest dealWithRequestBeforeSend(HttpRequest request) {
+        return request;
+    }
+
+    protected HttpResponse getResponse(HttpRequest request) {
+        byte[] responseBody = request.bytes();
+        int statusCode = request.code();
+        String reasonPhrase = request.message();
+        Map<String, List<String>> headers = request.headers();
+
+        return new HttpResponse(statusCode, responseBody, reasonPhrase, headers);
+    }
+
+    private void initialize() {
+        String tag = this.getClass().getName();
+        this.log = LoggerFactory.getLogger(tag);
+    }
+
+    private HttpRequest initializeRequest() throws MalformedURLException {
+        HttpRequest request = getRequest();
+
+        request.trustAllCerts();
+        request.trustAllHosts();
+
+        return request;
+    }
+
+    private void onCompleted(HttpResponse response) {
+        String result = response.isSuccessful() ? "OK" : "FAILED";
+        String reason = response.getReasonPhrase();
+        String responseBody = response.getBody();
+        int statusCode = response.getStatusCode();
+
+        log.trace("Response - {}: {} {} - {}", result, statusCode, reason, responseBody);
+    }
+}

--- a/src/main/java/no/cantara/base/commands/http/HttpResponse.java
+++ b/src/main/java/no/cantara/base/commands/http/HttpResponse.java
@@ -1,0 +1,58 @@
+package no.cantara.base.commands.http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class HttpResponse {
+    private static final Logger LOG = LoggerFactory.getLogger(HttpResponse.class);
+
+    private String body;
+    private int statusCode;
+    private Map<String, List<String>> headers;
+    private String reasonPhrase;
+
+    public HttpResponse(int statusCode, byte[] body, String reasonPhrase, Map<String, List<String>> headers) {
+        this(statusCode, new String(body), reasonPhrase, headers);
+    }
+
+    public HttpResponse(int statusCode, String body, String reasonPhrase, Map<String, List<String>> headers) {
+        this.body = body;
+        this.statusCode = statusCode;
+        this.reasonPhrase = reasonPhrase;
+        this.headers = headers;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public boolean isSuccessful() {
+        return statusCode >= 200 && statusCode < 300;
+    }
+
+    public String getReasonPhrase() {
+        return reasonPhrase;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public List<String> getHeader(String name) {
+        boolean containsHeader = headers != null && headers.containsKey(name);
+        if (!containsHeader) {
+            LOG.warn("Header with name {} not found", name);
+            return Collections.emptyList();
+        }
+
+        return headers.get(name);
+    }
+}

--- a/src/main/java/no/cantara/base/util/Property.java
+++ b/src/main/java/no/cantara/base/util/Property.java
@@ -1,0 +1,14 @@
+package no.cantara.base.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Property {
+    String key();
+
+    boolean required() default true;
+}

--- a/src/test/java/no/cantara/domainexample/DomainExampleConfiguration.java
+++ b/src/test/java/no/cantara/domainexample/DomainExampleConfiguration.java
@@ -1,0 +1,18 @@
+package no.cantara.domainexample;
+
+
+import no.cantara.base.util.Property;
+
+import java.net.URI;
+
+public interface DomainExampleConfiguration {
+    @Property(key = "domainexample.uri")
+    URI getDomainExampleServerUri();
+
+    @Property(key = "domainexample.username")
+    String getUsername();
+
+    @Property(key = "domainexample.password")
+    String getPassword();
+
+}

--- a/src/test/java/no/cantara/domainexample/TestDomainExampleConfiguration.java
+++ b/src/test/java/no/cantara/domainexample/TestDomainExampleConfiguration.java
@@ -1,0 +1,32 @@
+package no.cantara.domainexample;
+
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class TestDomainExampleConfiguration implements DomainExampleConfiguration {
+
+    @Override
+    public URI getDomainExampleServerUri() {
+        return createUri("http://vg.no");
+    }
+
+    @Override
+    public String getUsername() {
+        return "testuser";
+    }
+
+    @Override
+    public String getPassword() {
+        return "password";
+    }
+
+
+    private URI createUri(String uri) {
+        try {
+            return new URI(uri);
+        } catch (URISyntaxException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/src/test/java/no/cantara/domainexample/commands/DomainExampleBaseCommand.java
+++ b/src/test/java/no/cantara/domainexample/commands/DomainExampleBaseCommand.java
@@ -1,0 +1,23 @@
+package no.cantara.domainexample.commands;
+
+import no.cantara.base.commands.http.BaseHystrixHttpCommand;
+import no.cantara.domainexample.DomainExampleConfiguration;
+
+public abstract class DomainExampleBaseCommand<Result> extends BaseHystrixHttpCommand<Result> {
+    protected DomainExampleConfiguration configuration;
+    protected boolean fallback=false;
+
+    public DomainExampleBaseCommand() {
+        super("DomainExampleBaseCommand", 2500);
+    }
+
+    public DomainExampleBaseCommand withConfiguration(DomainExampleConfiguration configuration) {
+        this.configuration = configuration;
+        return this;
+    }
+
+    public DomainExampleBaseCommand<Result> withFallback(boolean fallback) {
+        this.fallback=fallback;
+        return this;
+    }
+}

--- a/src/test/java/no/cantara/domainexample/commands/GetSomethingFromDomainExampleCommand.java
+++ b/src/test/java/no/cantara/domainexample/commands/GetSomethingFromDomainExampleCommand.java
@@ -1,0 +1,56 @@
+package no.cantara.domainexample.commands;
+
+import com.github.kevinsawicki.http.HttpRequest;
+import no.cantara.base.commands.http.HttpResponse;
+import no.cantara.domainexample.DomainExampleConfiguration;
+import no.cantara.domainexample.tests.MyDomainContract;
+import no.cantara.domainexample.tests.MyDomainObject;
+
+import java.net.MalformedURLException;
+import java.util.UUID;
+
+public class GetSomethingFromDomainExampleCommand extends DomainExampleBaseCommand<MyDomainContract> {
+    private UUID firstParameter;
+    private UUID secondparameter;
+
+
+    public GetSomethingFromDomainExampleCommand withFallback(boolean fallback) {
+        return (GetSomethingFromDomainExampleCommand) super.withFallback(fallback);
+    }
+
+    public GetSomethingFromDomainExampleCommand withConfiguration(DomainExampleConfiguration configuration) {
+        return (GetSomethingFromDomainExampleCommand) super.withConfiguration(configuration);
+    }
+
+    public GetSomethingFromDomainExampleCommand withPatientId(UUID patientId) {
+        this.firstParameter = patientId;
+        return this;
+    }
+
+    public GetSomethingFromDomainExampleCommand withPrescriptionId(UUID prescriptionId) {
+        this.secondparameter = prescriptionId;
+        return this;
+    }
+
+    @Override
+    protected HttpRequest getRequest() throws MalformedURLException {
+        return null;
+    }
+
+    @Override
+    protected MyDomainContract dealWithResponse(HttpResponse response) {
+        return new MyDomainContract(firstParameter, populateMyDomainObject());
+    }
+
+    @Override
+    protected MyDomainContract getFallback(){
+        if (fallback){
+            return new MyDomainContract(firstParameter, populateMyDomainObject());
+        }
+        return null;
+    }
+
+    private MyDomainObject populateMyDomainObject() {
+        return new MyDomainObject();
+    }
+}

--- a/src/test/java/no/cantara/domainexample/commands/factories/SqlCommandFactory.java
+++ b/src/test/java/no/cantara/domainexample/commands/factories/SqlCommandFactory.java
@@ -1,0 +1,54 @@
+package no.cantara.domainexample.commands.factories;
+
+import no.cantara.domainexample.commands.sql.BaseHystrixSqlCommand;
+import no.cantara.domainexample.commands.sql.SqlQueryCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+import javax.sql.DataSource;
+
+public class SqlCommandFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(SqlCommandFactory.class);
+
+    private SingleConnectionDataSource singleConnectionDataSource;
+    private NamedParameterJdbcTemplate jdbcTemplate;
+    private NamedParameterJdbcTemplate singleConnectionTemplate;
+
+    public SqlCommandFactory(DataSource dataSource, SingleConnectionDataSource singleConnectionDataSource) {
+        this.singleConnectionDataSource = singleConnectionDataSource;
+
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+        this.singleConnectionTemplate = new NamedParameterJdbcTemplate(singleConnectionDataSource);
+    }
+
+    public <Command extends BaseHystrixSqlCommand> Command createCommand(Class<Command> targetClass) {
+        return createCommand(targetClass, jdbcTemplate);
+    }
+
+    public <Command extends BaseHystrixSqlCommand> Command createSingleConnectionCommand(Class<Command> targetClass) {
+        return createCommand(targetClass, singleConnectionTemplate);
+    }
+
+    public <T> SqlQueryCommand<T> createCommand(RowMapper<T> rowMapper) {
+        SqlQueryCommand<T> command = new SqlQueryCommand<T>(rowMapper);
+        command.withJdbcTemplate(jdbcTemplate);
+
+        return command;
+    }
+
+
+    private <Command extends BaseHystrixSqlCommand> Command createCommand(Class<Command> targetClass, NamedParameterJdbcTemplate jdbcTemplate) {
+        try {
+            Command command = targetClass.newInstance();
+            command.withJdbcTemplate(jdbcTemplate);
+
+            return command;
+        } catch (Exception exception) {
+            LOG.error("Failed to create SQL command", exception);
+            return null;
+        }
+    }
+}

--- a/src/test/java/no/cantara/domainexample/commands/sql/BaseHystrixSqlCommand.java
+++ b/src/test/java/no/cantara/domainexample/commands/sql/BaseHystrixSqlCommand.java
@@ -1,0 +1,56 @@
+package no.cantara.domainexample.commands.sql;
+
+import no.cantara.base.commands.BaseHystrixCommand;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+public abstract class BaseHystrixSqlCommand<CommandType extends BaseHystrixSqlCommand, ReturnType> extends BaseHystrixCommand<ReturnType> {
+    protected static final Logger LOG = LoggerFactory.getLogger(BaseHystrixSqlCommand.class);
+
+    protected String sql;
+    protected NamedParameterJdbcTemplate jdbcTemplate;
+
+    public BaseHystrixSqlCommand() {
+        super("sql", 3000);
+    }
+
+    public BaseHystrixSqlCommand withJdbcTemplate(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public CommandType withStatement(String sql) {
+        this.sql = sql;
+        return (CommandType) this;
+    }
+
+    @Override
+    protected ReturnType run() throws Exception {
+        try {
+            validate();
+            return executeQuery();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    protected abstract ReturnType executeQuery();
+
+    protected void validate() throws Exception {
+        boolean isSqlStatementSet = StringUtils.isNotBlank(sql);
+        if (isSqlStatementSet) {
+            throw new Exception("Invalid state - No SQL statement is set");
+        } else {
+            LOG.trace("SQL command executed with statement: \n{}", sql);
+        }
+
+        boolean isJdbcTemplateSet = jdbcTemplate != null;
+        if (!isJdbcTemplateSet) {
+            throw new Exception("Invalid state - No JDBC template is set");
+        }
+    }
+}

--- a/src/test/java/no/cantara/domainexample/commands/sql/SqlBatchUpdateCommand.java
+++ b/src/test/java/no/cantara/domainexample/commands/sql/SqlBatchUpdateCommand.java
@@ -1,0 +1,27 @@
+package no.cantara.domainexample.commands.sql;
+
+import java.util.Map;
+
+public class SqlBatchUpdateCommand extends BaseHystrixSqlCommand<SqlBatchUpdateCommand, int[]> {
+    protected Map<String, Object>[] parameters;
+
+    public SqlBatchUpdateCommand withParameters(Map<String, Object>[] parameters) {
+        this.parameters = parameters;
+        return this;
+    }
+
+    @Override
+    protected int[] executeQuery() {
+        return jdbcTemplate.batchUpdate(sql, parameters);
+    }
+
+    @Override
+    protected void validate() throws Exception {
+        super.validate();
+
+        boolean isParametersSet = parameters != null;
+        if (!isParametersSet) {
+            throw new Exception("Invalid state - No parameters is set");
+        }
+    }
+}

--- a/src/test/java/no/cantara/domainexample/commands/sql/SqlNamedParameterCommand.java
+++ b/src/test/java/no/cantara/domainexample/commands/sql/SqlNamedParameterCommand.java
@@ -1,0 +1,37 @@
+package no.cantara.domainexample.commands.sql;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class SqlNamedParameterCommand<CommandType extends SqlNamedParameterCommand, ReturnType> extends BaseHystrixSqlCommand<CommandType, ReturnType> {
+    protected Map<String, Object> parameters;
+
+    @SuppressWarnings("unchecked")
+    public CommandType withParameters(Map<String, Object> parameters) {
+        this.parameters = parameters;
+        return (CommandType) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public CommandType addParameter(String key, Object value) {
+        boolean isParametersSet = parameters != null;
+        if (!isParametersSet) {
+            parameters = new HashMap<String, Object>();
+        }
+
+        this.parameters.put(key, value);
+        return (CommandType) this;
+    }
+
+    @Override
+    protected void validate() throws Exception {
+        super.validate();
+
+        boolean isParametersSet = parameters != null;
+        if (!isParametersSet) {
+            throw new Exception("Invalid state - No parameters is set");
+        } else {
+            LOG.trace("SQL command executed with parameters: \n{}", parameters);
+        }
+    }
+}

--- a/src/test/java/no/cantara/domainexample/commands/sql/SqlQueryCommand.java
+++ b/src/test/java/no/cantara/domainexample/commands/sql/SqlQueryCommand.java
@@ -1,0 +1,18 @@
+package no.cantara.domainexample.commands.sql;
+
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.List;
+
+public class SqlQueryCommand<ReturnType> extends SqlNamedParameterCommand<SqlQueryCommand<ReturnType>, List<ReturnType>> {
+    private RowMapper<ReturnType> rowMapper;
+
+    public SqlQueryCommand(RowMapper<ReturnType> rowMapper) {
+        this.rowMapper = rowMapper;
+    }
+
+    @Override
+    protected List<ReturnType> executeQuery() {
+        return jdbcTemplate.query(sql, parameters, rowMapper);
+    }
+}

--- a/src/test/java/no/cantara/domainexample/commands/sql/SqlUpdateCommand.java
+++ b/src/test/java/no/cantara/domainexample/commands/sql/SqlUpdateCommand.java
@@ -1,0 +1,9 @@
+package no.cantara.domainexample.commands.sql;
+
+public class SqlUpdateCommand extends SqlNamedParameterCommand<SqlUpdateCommand, Integer> {
+
+    @Override
+    protected Integer executeQuery() {
+        return jdbcTemplate.update(sql, parameters);
+    }
+}

--- a/src/test/java/no/cantara/domainexample/tests/DomainExampleCommandBaseTest.java
+++ b/src/test/java/no/cantara/domainexample/tests/DomainExampleCommandBaseTest.java
@@ -1,0 +1,25 @@
+package no.cantara.domainexample.tests;
+
+import no.cantara.domainexample.DomainExampleConfiguration;
+import no.cantara.domainexample.TestDomainExampleConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+@Test(groups = { "DomainExampleCommandBaseTest" })
+public class DomainExampleCommandBaseTest {
+    private final static Logger LOG = LoggerFactory.getLogger(DomainExampleCommandBaseTest.class);
+
+    protected static DomainExampleConfiguration configuration = new TestDomainExampleConfiguration() {
+    };
+
+    @BeforeGroups(value = { "DomainExampleCommandBaseTest" })
+    public void setup() {
+        LOG.debug("DomainExampleCommandBaseTest setup: {}");
+    }
+
+
+
+}
+

--- a/src/test/java/no/cantara/domainexample/tests/GetSomethingFromDomainExampleCommandTest.java
+++ b/src/test/java/no/cantara/domainexample/tests/GetSomethingFromDomainExampleCommandTest.java
@@ -1,0 +1,28 @@
+package no.cantara.domainexample.tests;
+
+import no.cantara.domainexample.commands.GetSomethingFromDomainExampleCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+
+import static org.testng.Assert.assertNotNull;
+
+public class GetSomethingFromDomainExampleCommandTest extends DomainExampleCommandBaseTest {
+    private final static Logger LOG = LoggerFactory.getLogger(GetSomethingFromDomainExampleCommandTest.class);
+
+    @Test
+    public void test_GetSomethingFromDomainExampleCommand() throws Exception {
+        MyDomainContract myDomainContract = new GetSomethingFromDomainExampleCommand()
+            .withFallback(true)
+            .withConfiguration(configuration)
+            .withPatientId(UUID.randomUUID())
+            .withPrescriptionId(UUID.randomUUID())
+            .execute();
+
+        LOG.debug("Got myDomainContract: {}",myDomainContract);
+
+        assertNotNull(myDomainContract);
+    }
+}

--- a/src/test/java/no/cantara/domainexample/tests/MyDomainContract.java
+++ b/src/test/java/no/cantara/domainexample/tests/MyDomainContract.java
@@ -1,0 +1,23 @@
+package no.cantara.domainexample.tests;
+
+
+import java.util.UUID;
+
+public class MyDomainContract {
+
+    private UUID firstParameter;
+    private MyDomainObject myDomainObject;
+
+    public MyDomainContract(UUID firstParameter, MyDomainObject myDomainObject) {
+        this.firstParameter = firstParameter;
+        this.myDomainObject = myDomainObject;
+    }
+
+    public UUID getFirstParameter() {
+        return firstParameter;
+    }
+
+    public MyDomainObject getMyDomainObject() {
+        return myDomainObject;
+    }
+}

--- a/src/test/java/no/cantara/domainexample/tests/MyDomainObject.java
+++ b/src/test/java/no/cantara/domainexample/tests/MyDomainObject.java
@@ -1,0 +1,4 @@
+package no.cantara.domainexample.tests;
+
+public class MyDomainObject {
+}


### PR DESCRIPTION
Moved JDBC hystrix commands and spring to tests/test-scope as examples of how to extend this to JDBC without having Spring dependencies++ in the JAR-file